### PR TITLE
Fix issue with undefined index.

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -128,7 +128,9 @@ function scripts() {
 	);
 
 	// Localize the script so we can have access to the settings.
-	$settings = get_option( 'amfwp_settings', [] );
+	$settings = get_option( 'amfwp_settings', [
+		'long_life_token' => '',
+	] );
 	wp_localize_script( 'mapkitjs', 'AMFWP', [ 'longLifeToken' => $settings['long_life_token'] ] );
 }
 


### PR DESCRIPTION
When settings have never been updated, the `long_life_token` key is not set and throws an error.