### PR TITLE
Fix spelling and button label text in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ In order to start using the Apple Maps block, you will need to sign up for the A
 1. [Create a Maps ID and a MapKit JS Private Key](https://developer.apple.com/documentation/mapkitjs/creating_a_maps_identifier_and_a_private_key).
 1. Copy the Private Key, paste it into the respective plugin setup field, and ensure the key includes the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines.
 1. Open the Key you created in Step 1, copy the `Key ID` value, and paste it into the respective plugin setup field.
-1. Open the Identifier you created in Step 1, copy the `App ID Prefix` value (notice the value is appened with `(Team ID)`), and paste it into the respective plugin setup field.
-1. Click the `Save API Key` button in the plugin setup to gain access to the block options and begin customizing your Apple Maps block!
+1. Open the Identifier you created in Step 1, copy the `App ID Prefix` value (notice the value is appended with `(Team ID)`), and paste it into the respective plugin setup field.
+1. Click the `Confirm MapKit Credentials` button in the plugin setup to gain access to the block options and begin customizing your Apple Maps block!
 
 ## Frequently Asked Questions
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,8 +37,8 @@ In order to start using the Apple Maps block, you will need to sign up for the A
 1. [Create a Maps ID and a MapKit JS Private Key](https://developer.apple.com/documentation/mapkitjs/creating_a_maps_identifier_and_a_private_key).
 1. Copy the Private Key, paste it into the respective plugin setup field, and ensure the key includes the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines.
 1. Open the Key you created in Step 1, copy the `Key ID` value, and paste it into the respective plugin setup field.
-1. Open the Identifier you created in Step 1, copy the `App ID Prefix` value (notice the value is appened with `(Team ID)`), and paste it into the respective plugin setup field.
-1. Click the `Save API Key` button in the plugin setup to gain access to the block options and begin customizing your Apple Maps block!
+1. Open the Identifier you created in Step 1, copy the `App ID Prefix` value (notice the value is appended with `(Team ID)`), and paste it into the respective plugin setup field.
+1. Click the `Confirm MapKit Credentials` button in the plugin setup to gain access to the block options and begin customizing your Apple Maps block!
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In crafting the setup steps for the plugin settings I noticed a spelling error and incorrect button label reference in our readmes.  This PR resolves those issues.

### Alternate Designs

n/a

### Benefits

Ensures our readme matches the plugin settings.

### Possible Drawbacks

none identified.

### Verification Process

Manually reviewed via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a