### PR TITLE
Add mapkit limits to FAQ in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ There is a free daily limit of 250,000 map views and 25,000 service calls per th
 
 ### Can I see how many map views and service requests are made to my MapKit JS Private Key?
 
-Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also Mmonitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
+Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also monitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
 
 ## Support Level
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ In order to start using the Apple Maps block, you will need to sign up for the A
 
 If you have WordPress installed in a subdirectory, then there is a [known issue](https://github.com/10up/maps-block-apple/issues/34) specifically related to this setup where the WordPress Admin URL is different from the site URL.  We're working on a [minor release](https://github.com/10up/maps-block-apple/milestone/3) to resolve this issue.
 
+### Are there any MapKit JS rate limits?
+
+There is a free daily limit of 250,000 map views and 25,000 service calls per the Apple Developer Program membership.  For additional MapKit JS capacity needs you will need to [contact Apple directly](https://developer.apple.com/contact/request/mapkitjs/).
+
 ### Can I see how many map views and service requests are made to my MapKit JS Private Key?
 
-Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).
+Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also Mmonitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
 
 ## Support Level
 

--- a/readme.txt
+++ b/readme.txt
@@ -45,10 +45,14 @@ In order to start using the Apple Maps block, you will need to sign up for the A
 = I'm seeing validation errors when trying to authenticate my MapKit JS credentials, what am I doing wrong? =
 
 If you have WordPress installed in a subdirectory, then there is a [known issue](https://github.com/10up/maps-block-apple/issues/34) specifically related to this setup where the WordPress Admin URL is different from the site URL.  We're working on a [minor release](https://github.com/10up/maps-block-apple/milestone/3) to resolve this issue.
- 
+
+= Are there any MapKit JS rate limits? =
+
+There is a free daily limit of 250,000 map views and 25,000 service calls per the Apple Developer Program membership.  For additional MapKit JS capacity needs you will need to [contact Apple directly](https://developer.apple.com/contact/request/mapkitjs/).
+
 = Can I see how many map views and service requests are made to my MapKit JS Private Key? =
- 
-Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).
+
+Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also Mmonitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ There is a free daily limit of 250,000 map views and 25,000 service calls per th
 
 = Can I see how many map views and service requests are made to my MapKit JS Private Key? =
 
-Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also Mmonitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
+Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also monitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
 
 == Screenshots ==
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

To help further inform plugin users, we should specifically note the daily limits from Apple on utilizing the MapKit JS API.  This PR adds that to the FAQ sections of the README.md and readme.txt files to surface that info on GitHub and WordPress.org.

### Alternate Designs

n/a

### Benefits

Ensures plugin users are aware of their daily limits and how to get those increased via Apple.

### Possible Drawbacks

None identified.

### Verification Process

Manually reviewed via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
n/a