### PR TITLE
Require WP 5.2+

### DIFF
--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -11,7 +11,6 @@
  * License:           GPLv2 or later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       maps-block-apple
- * Domain Path:       /languages
  *
  * @package           tenup\Maps_Block_Apple
  */
@@ -25,7 +24,21 @@ define( 'MAPS_BLOCK_APPLE_PATH', dirname( __FILE__ ) . '/' );
 define( 'MAPS_BLOCK_APPLE_INC', MAPS_BLOCK_APPLE_PATH . 'includes/' );
 define( 'MAPS_BLOCK_APPLE_BASENAME', plugin_basename( __FILE__ ) );
 
-add_action( 'init', __NAMESPACE__ . '\add_options' );
+/**
+ * Require PHP version 5.6 - throw an error if the plugin is activated on an older version.
+ */
+register_activation_hook(
+	__FILE__,
+	function() {
+		if ( ! version_compare( $GLOBALS['wp_version'], '5.2', '>=' ) ) {
+			wp_die(
+				esc_html__( 'Block for Apple Maps requires WordPress version 5.2 or greater.', 'maps-block-apple' ),
+				esc_html__( 'Error Activating', 'maps-block-apple' )
+			);
+		}
+	}
+);
+
 /**
  * Add options
  */
@@ -34,6 +47,7 @@ function add_options() {
 	add_option( 'maps_block_apple_key_id' );
 	add_option( 'maps_block_apple_private_key' );
 }
+add_action( 'init', __NAMESPACE__ . '\add_options' );
 
 require_once MAPS_BLOCK_APPLE_INC . 'block_assets.php';
 require_once MAPS_BLOCK_APPLE_INC . 'rest_routes.php';

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -25,7 +25,8 @@ define( 'MAPS_BLOCK_APPLE_INC', MAPS_BLOCK_APPLE_PATH . 'includes/' );
 define( 'MAPS_BLOCK_APPLE_BASENAME', plugin_basename( __FILE__ ) );
 
 /**
- * Require PHP version 5.6 - throw an error if the plugin is activated on an older version.
+ * Require WP version 5.2+ beacuse of hooks.
+ * PHP 5.6 errors should be caught in the sandbox during activation.
  */
 register_activation_hook(
 	__FILE__,


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Throw an error if the user manages to install and tries to activate the plugin in WP < 5.2 - note that it shouldn't show up in search results so this would mean they downloaded and uploaded the plugin manually. This is method we've used elsewhere - shows a `wp_die()` message and you have to navigate back in the browser. PHP errors should be caught in sandboxing and prevent activation which is IMO a better experience because you stay on the plugins screen but can add that later if it becomes an issue.

### Alternate Designs

Originally discussed Gutenberg detection, but we're far enough along now from original introduction to core that it doesn't seem reasonable to maintain that overhead of testing to start.

### Benefits

Avoid issues with people activating the plugin with expectations that it work in old WP.

### Possible Drawbacks

n/a

### Verification Process

Set it to `5.7` in my local and made sure it bailed.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixes #14 

### Changelog Entry


