### PR TITLE
Fix: authorization mapkit issue

### DIFF
--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -69,7 +69,7 @@ function get_jwt() {
 		return new WP_Error( 'InvalidKey', 'Invalid Team ID', [ 'status' => 401 ] );
 	}
 	if (
-		0 !== strpos( $private_key, '-----BEGIN PRIVATE KEY-----')
+		0 !== strpos( $private_key, '-----BEGIN PRIVATE KEY-----' )
 		&& ! strpos( $private_key, '-----END PRIVATE KEY-----' )
 	) {
 		return new WP_Error( 'InvalidKey', 'Invalid Private Key', [ 'status' => 401 ] );

--- a/src/components/AppleMap.js
+++ b/src/components/AppleMap.js
@@ -161,8 +161,8 @@ class AppleMap {
 						 * JWT only lives for 30 mins. Calling it again here to
 						 * allow mapkit to get new token when needed.
 						 *
-						 * @link https://github.com/10up/maps-block-apple/issues/48
-						 * @link https://github.com/10up/maps-block-apple/pull/52
+						 * @see https://github.com/10up/maps-block-apple/issues/48
+						 * @see https://github.com/10up/maps-block-apple/pull/52
 						 */
 						apiFetch( { path: 'MapsBlockApple/v1/GetJWT/' } ).then(
 							done


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
We have a problem with mapkit authorization inside the block after merging #52: We can't authorize mapkit anymore. The reason is initializing mapkit before checking for credentials, which is done inside `MapsBlockApple/v1/GetJWT/`. This PR fixes that bug by calling the API first to make sure all three credentials fields are set before initialization.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->