### PR TITLE
Feature/make map resizable using resize handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/), and will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
-
+### Added
+- Resize Handle to modify the height of the Map inline
 ## [1.0.1] - 2020-08-11
 ### Added
 - Internationalization support via loading translations for the block (props [@dinhtungdu](https://github.com/dinhtungdu), [@helen](https://github.com/helen) via [#69](https://github.com/10up/maps-block-apple/pull/69))

--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -24,8 +24,9 @@ function add_endpoints() {
 		MAPS_BLOCK_APPLE_VERSION_REST_NAMESPACE,
 		'/GetJWT',
 		[
-			'methods'  => 'GET',
-			'callback' => __NAMESPACE__ . '\get_jwt',
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\get_jwt',
+			'permission_callback' => '__return_true',
 		]
 	);
 }

--- a/src/components/ResizableMap.js
+++ b/src/components/ResizableMap.js
@@ -1,0 +1,55 @@
+import {
+	ResizableBox,
+} from '@wordpress/components';
+
+const RESIZABLE_BOX_ENABLE_OPTION = {
+	top: false,
+	right: false,
+	bottom: true,
+	left: false,
+	topRight: false,
+	bottomRight: false,
+	bottomLeft: false,
+	topLeft: false,
+};
+
+const MAP_MIN_HEIGHT = 100;
+
+export function ResizableMap( {
+	onResizeStart,
+	onResize,
+	onResizeStop,
+	...props
+} ) {
+	const [ isResizing, setIsResizing ] = useState( false );
+
+	return (
+		<ResizableBox
+			style={{
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				right: 0,
+				bottom: 0,
+			}}
+			className={ `apple-maps-block__resize-container ${isResizing ? 'is-resizing' : ''}` }
+			enable={ RESIZABLE_BOX_ENABLE_OPTION }
+			onResizeStart={ ( _event, _direction, elt ) => {
+				onResizeStart( elt.clientHeight );
+				onResize( elt.clientHeight );
+			} }
+			onResize={ ( _event, _direction, elt ) => {
+				onResize( elt.clientHeight );
+				if ( ! isResizing ) {
+					setIsResizing( true );
+				}
+			} }
+			onResizeStop={ ( _event, _direction, elt ) => {
+				onResizeStop( elt.clientHeight );
+				setIsResizing( false );
+			} }
+			minHeight={ MAP_MIN_HEIGHT }
+			{ ...props }
+		/>
+	);
+}

--- a/src/components/ResizableMap.js
+++ b/src/components/ResizableMap.js
@@ -1,6 +1,5 @@
-import {
-	ResizableBox,
-} from '@wordpress/components';
+import { ResizableBox } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 const RESIZABLE_BOX_ENABLE_OPTION = {
 	top: false,

--- a/src/edit.js
+++ b/src/edit.js
@@ -3,7 +3,6 @@ import {
 	Placeholder,
 	Toolbar,
 	ToolbarButton,
-	ResizableBox,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -16,6 +15,7 @@ import InspectorSettings from './inspector-settings';
 import IsAdmin from './helper';
 import BlockIcon from './block-icon';
 import { debounce } from 'lodash';
+import { ResizableMap } from './components/ResizableMap'
 
 export default function MapsBlockAppleEdit( props ) {
 	const {
@@ -264,57 +264,5 @@ export default function MapsBlockAppleEdit( props ) {
 				) ) }
 			</div>
 		</>
-	);
-}
-
-const RESIZABLE_BOX_ENABLE_OPTION = {
-	top: false,
-	right: false,
-	bottom: true,
-	left: false,
-	topRight: false,
-	bottomRight: false,
-	bottomLeft: false,
-	topLeft: false,
-};
-
-const MAP_MIN_HEIGHT = 100;
-
-function ResizableMap( {
-	onResizeStart,
-	onResize,
-	onResizeStop,
-	...props
-} ) {
-	const [ isResizing, setIsResizing ] = useState( false );
-
-	return (
-		<ResizableBox
-			style={{
-				position: 'absolute',
-				top: 0,
-				left: 0,
-				right: 0,
-				bottom: 0,
-			}}
-			className={ `apple-maps-block__resize-container ${isResizing ? 'is-resizing' : ''}` }
-			enable={ RESIZABLE_BOX_ENABLE_OPTION }
-			onResizeStart={ ( _event, _direction, elt ) => {
-				onResizeStart( elt.clientHeight );
-				onResize( elt.clientHeight );
-			} }
-			onResize={ ( _event, _direction, elt ) => {
-				onResize( elt.clientHeight );
-				if ( ! isResizing ) {
-					setIsResizing( true );
-				}
-			} }
-			onResizeStop={ ( _event, _direction, elt ) => {
-				onResizeStop( elt.clientHeight );
-				setIsResizing( false );
-			} }
-			minHeight={ MAP_MIN_HEIGHT }
-			{ ...props }
-		/>
 	);
 }


### PR DESCRIPTION
### Description of the Change

Inspired by the Core Cover Block I have added a Resize handle to the Apple Maps Block. This allows editors to just drag the size of the map to get the expected results. 

https://user-images.githubusercontent.com/20684594/111866640-2a5c4f80-896f-11eb-9bed-a2c20bac3e28.mov



### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.
