### PR TITLE
#85 - Enqueue map assets only when being used / Clean up unused assets

### DIFF
--- a/block.json
+++ b/block.json
@@ -1,72 +1,90 @@
 {
-	"name": "tenup/maps-block-apple",
-	"title": "Apple Maps",
-	"category": "embed",
-	"icon": "<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 40 52'><path fill='#333' fillRule='evenodd' d='M37.15 9.802c0 4.936-3.698 9.05-8.46 9.709v11.854l-1.304 3.92-1.303-3.92V19.521c-4.8-.626-8.536-4.757-8.536-9.72 0-5.39 4.41-9.801 9.802-9.801 5.39 0 9.801 4.41 9.801 9.802zm-15.224-2.38c.74.633 2.088.274 3.01-.802.922-1.077 1.068-2.464.327-3.098-.74-.634-2.088-.275-3.01.802-.921 1.076-1.068 2.463-.327 3.097z' clipRule='evenodd'></path><path fill='#333' d='M12.85 25l11.277 3.776v2.589l3.26 8.821 3.258-8.821v-2.483L40 25v21.736l-12.124 4.93-15.026-4.93L0 51.666V30.032L12.85 25z'></path></svg>",
-	"description": "An Apple Maps block.",
-	"keywords": [ "apple", "map", "apple map" ],
-  "attributes": {
- 		"address": {
- 			"type": "string",
- 			"default": ""
- 		},
- 		"height": {
- 			"type": "string",
- 			"default": "450"
- 		},
- 		"latitude": {
- 			"type": "number",
- 			"default": 51.48762585296625
- 		},
- 		"longitude": {
- 			"type": "number",
- 			"default": -0.1326724377053381
- 		},
- 		"rotation": {
- 			"type": "number",
- 			"default": 0
- 		},
- 		"zoom": {
- 			"type": "number",
- 			"default": 15
- 		},
- 		"mapType": {
- 			"type": "string",
- 			"default": "Map.MapTypes.Standard"
- 		},
- 		"showsMapTypeControl": {
- 			"type": "boolean",
- 			"default": true
- 		},
- 		"isRotationEnabled": {
- 			"type": "boolean",
- 			"default": true
- 		},
- 		"showsCompass": {
- 			"type": "string",
- 			"default": "FeatureVisibility.Adaptive"
- 		},
- 		"isZoomEnabled": {
- 			"type": "boolean",
- 			"default": true
- 		},
- 		"showsZoomControl": {
- 			"type": "boolean",
- 			"default": true
- 		},
- 		"isScrollEnabled": {
- 			"type": "boolean",
- 			"default": true
- 		},
- 		"showsScale": {
- 			"type": "string",
- 			"default": "FeatureVisibility.Adaptive"
- 		},
- 		"markers": {
- 			"type": "array",
- 			"default": []
- 		}
- 	},
-	"editorScript": "file:build/index.js",
-	"script": "file:build/frontend.js"
+  "name":"tenup/maps-block-apple",
+  "title":"Apple Maps",
+  "category":"embed",
+  "description":"Add an Apple Map to your site.",
+  "keywords":[
+    "apple",
+    "map",
+    "apple map"
+  ],
+  "attributes":{
+    "address":{
+      "type":"string",
+      "default":""
+    },
+    "height":{
+      "type":"string",
+      "default":"450"
+    },
+    "latitude":{
+      "type":"number",
+      "default":51.48762585296625
+    },
+    "longitude":{
+      "type":"number",
+      "default":-0.1326724377053381
+    },
+    "rotation":{
+      "type":"number",
+      "default":0
+    },
+    "zoom":{
+      "type":"number",
+      "default":15
+    },
+    "mapType":{
+      "type":"string",
+      "default":"standard"
+    },
+    "showsMapTypeControl":{
+      "type":"boolean",
+      "default":true
+    },
+    "isRotationEnabled":{
+      "type":"boolean",
+      "default":true
+    },
+    "showsCompass":{
+      "type":"string",
+      "default":"adaptive"
+    },
+    "isZoomEnabled":{
+      "type":"boolean",
+      "default":true
+    },
+    "showsZoomControl":{
+      "type":"boolean",
+      "default":true
+    },
+    "isScrollEnabled":{
+      "type":"boolean",
+      "default":true
+    },
+    "showsScale":{
+      "type":"string",
+      "default":"adaptive"
+    },
+    "markers":{
+      "type":"array",
+      "default":[
+
+      ]
+    }
+  },
+  "example":{
+    "attributes":{
+      "latitude":51.48762585296625,
+      "longitude":-0.1326724377053381
+    }
+  },
+  "supports":{
+    "align":[
+      "wide",
+      "full"
+    ],
+    "html":false
+  },
+  "editorScript":"maps-block-apple-block",
+  "script":"maps-block-apple-frontend"
 }

--- a/block.json
+++ b/block.json
@@ -67,8 +67,5 @@
  			"default": []
  		}
  	},
-	"editorScript": "file:build/index.js",
-	"editorStyle": "file:editor.css",
-  "script": "file:build/frontend.js",
-	"style": "file:style.css"
+	"editorScript": "file:build/index.js"
 }

--- a/block.json
+++ b/block.json
@@ -67,5 +67,6 @@
  			"default": []
  		}
  	},
-	"editorScript": "file:build/index.js"
+	"editorScript": "file:build/index.js",
+	"script": "file:build/frontend.js"
 }

--- a/editor.css
+++ b/editor.css
@@ -1,3 +1,0 @@
-[data-type="10up/maps-block-apple"] {
-
-}

--- a/includes/block-assets.php
+++ b/includes/block-assets.php
@@ -13,7 +13,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block_assets' );
  */
 function register_block_assets() {
 
-	wp_enqueue_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', [], 5, false );
+	wp_register_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', [], 5, false );
 
 	$file_name           = 'index';
 	$script_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$file_name.asset.php" );
@@ -33,38 +33,22 @@ function register_block_assets() {
 		]
 	);
 
-	wp_register_style(
-		'maps-block-apple-style',
-		MAPS_BLOCK_APPLE_URL . 'style.css',
-		[],
-		$script_dependencies['version']
-	);
-
-	wp_register_style(
-		'maps-block-apple-editor-style',
-		MAPS_BLOCK_APPLE_URL . 'editor.css',
-		[],
-		$script_dependencies['version']
-	);
-
 	register_block_type(
 		'tenup/maps-block-apple',
 		[
-			'editor_script' => 'maps-block-apple-block',
-			'editor_style'  => 'maps-block-apple-editor-style',
-			'style'         => 'maps-block-apple-style',
+			'editor_script' => 'maps-block-apple-block'
 		]
 	);
 
 }
 
-add_action( 'init', __NAMESPACE__ . '\register_frontend_assets' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_frontend_assets' );
 /**
  * Register block assets
  */
 function register_frontend_assets() {
-	// If in the backend, bail out.
-	if ( is_admin() ) {
+	// If not single post display and does not have the map block then bail.
+	if ( ! is_singular() || ! has_block( 'tenup/maps-block-apple' ) ) {
 		return;
 	}
 

--- a/includes/block-assets.php
+++ b/includes/block-assets.php
@@ -64,13 +64,7 @@ function register_block_assets() {
 		false
 	);
 
-	register_block_type(
-		'tenup/maps-block-apple',
-		[
-			'editor_script' => 'maps-block-apple-block',
-			'script'        => 'maps-block-apple-frontend',
-		]
-	);
+	register_block_type( MAPS_BLOCK_APPLE_PATH );
 
 }
 

--- a/includes/block-assets.php
+++ b/includes/block-assets.php
@@ -13,18 +13,38 @@ add_action( 'init', __NAMESPACE__ . '\register_block_assets' );
  */
 function register_block_assets() {
 
-	wp_register_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', [], 5, false );
-
-	$file_name           = 'index';
-	$script_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$file_name.asset.php" );
-	wp_register_script(
-		'maps-block-apple-block',
-		MAPS_BLOCK_APPLE_URL . "build/$file_name.js",
-		array_merge( $script_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
-		$script_dependencies['version'],
-		false
+	// Admin Settings Page Style
+	wp_register_style(
+		'maps-block-apple-settings',
+		trailingslashit( MAPS_BLOCK_APPLE_URL ) . 'assets/css/admin-maps-block-apple-settings.css',
+		[],
+		MAPS_BLOCK_APPLE_VERSION
 	);
 
+	// Mapkit Library
+	wp_register_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', [], 5, false );
+
+	// Admin Settings Script
+	$settings_file_name    = 'admin-settings';
+	$settings_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$settings_file_name.asset.php" );
+	wp_register_script(
+		'maps-block-apple-settings',
+		MAPS_BLOCK_APPLE_URL . "build/$settings_file_name.js",
+		array_merge( $settings_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
+		$settings_dependencies['version'],
+		true
+	);
+
+	// Block Editorial Script
+	$block_file_name    = 'index';
+	$block_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$block_file_name.asset.php" );
+	wp_register_script(
+		'maps-block-apple-block',
+		MAPS_BLOCK_APPLE_URL . "build/$block_file_name.js",
+		array_merge( $block_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
+		$block_dependencies['version'],
+		false
+	);
 	wp_localize_script(
 		'maps-block-apple-block',
 		'_mbaData',
@@ -33,34 +53,25 @@ function register_block_assets() {
 		]
 	);
 
-	register_block_type(
-		'tenup/maps-block-apple',
-		[
-			'editor_script' => 'maps-block-apple-block'
-		]
-	);
-
-}
-
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\register_frontend_assets' );
-/**
- * Register block assets
- */
-function register_frontend_assets() {
-	// If not single post display and does not have the map block then bail.
-	if ( ! is_singular() || ! has_block( 'tenup/maps-block-apple' ) ) {
-		return;
-	}
-
-	$file_name             = 'frontend';
-	$frontend_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$file_name.asset.php" );
-	wp_enqueue_script(
+	// FE Block Script
+	$fe_file_name          = 'frontend';
+	$frontend_dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$fe_file_name.asset.php" );
+	wp_register_script(
 		'maps-block-apple-frontend',
-		MAPS_BLOCK_APPLE_URL . "build/$file_name.js",
+		MAPS_BLOCK_APPLE_URL . "build/$fe_file_name.js",
 		array_merge( $frontend_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
 		$frontend_dependencies['version'],
 		false
 	);
+
+	register_block_type(
+		'tenup/maps-block-apple',
+		[
+			'editor_script' => 'maps-block-apple-block',
+			'script'        => 'maps-block-apple-frontend',
+		]
+	);
+
 }
 
 add_action( 'init', __NAMESPACE__ . '\set_script_translations' );

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -146,22 +146,9 @@ function enqueue_settings_assets( $screen_id ) {
 	if ( ! $screen_id || 'settings_page_block-for-apple-maps' !== $screen_id ) {
 		return;
 	}
-	wp_enqueue_style(
-		'admin_block_for_apple_maps',
-		trailingslashit( MAPS_BLOCK_APPLE_URL ) . 'assets/css/admin-maps-block-apple-settings.css',
-		[],
-		MAPS_BLOCK_APPLE_VERSION
-	);
 
-	$file_name    = 'admin-settings';
-	$dependencies = ( include MAPS_BLOCK_APPLE_PATH . "build/$file_name.asset.php" );
-	wp_enqueue_script(
-		'maps-block-apple-frontend',
-		MAPS_BLOCK_APPLE_URL . "build/$file_name.js",
-		array_merge( $dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
-		$dependencies['version'],
-		true
-	);
+	wp_enqueue_style( 'maps-block-apple-settings' );
+	wp_enqueue_script( 'maps-block-apple-settings' );
 }
 
 /**

--- a/src/components/ResizableMap.js
+++ b/src/components/ResizableMap.js
@@ -24,14 +24,16 @@ export function ResizableMap( {
 
 	return (
 		<ResizableBox
-			style={{
+			style={ {
 				position: 'absolute',
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
-			}}
-			className={ `apple-maps-block__resize-container ${isResizing ? 'is-resizing' : ''}` }
+			} }
+			className={ `apple-maps-block__resize-container ${
+				isResizing ? 'is-resizing' : ''
+			}` }
 			enable={ RESIZABLE_BOX_ENABLE_OPTION }
 			onResizeStart={ ( _event, _direction, elt ) => {
 				onResizeStart( elt.clientHeight );

--- a/src/edit.js
+++ b/src/edit.js
@@ -15,7 +15,7 @@ import InspectorSettings from './inspector-settings';
 import IsAdmin from './helper';
 import BlockIcon from './block-icon';
 import { debounce } from 'lodash';
-import { ResizableMap } from './components/ResizableMap'
+import { ResizableMap } from './components/ResizableMap';
 
 export default function MapsBlockAppleEdit( props ) {
 	const {
@@ -224,8 +224,8 @@ export default function MapsBlockAppleEdit( props ) {
 				onResizeStart={ () => {
 					toggleSelection( false );
 				} }
-				onResize={ (newHeight) => {
-					setAttributes( { height: newHeight } )
+				onResize={ ( newHeight ) => {
+					setAttributes( { height: newHeight } );
 				} }
 				onResizeStop={ ( newHeight ) => {
 					toggleSelection( true );

--- a/src/index.js
+++ b/src/index.js
@@ -15,83 +15,23 @@ import { registerBlockType } from '@wordpress/blocks';
 import MapsBlockAppleEdit from './edit';
 import MapsBlockAppleSave from './save';
 import BlockIcon from './block-icon';
+import metadata from './../block.json';
 
-registerBlockType( 'tenup/maps-block-apple', {
-	title: __( 'Apple Maps', 'maps-block-apple' ),
-	description: __( 'Add an Apple Map to your site.', 'maps-block-apple' ),
-	category: 'embed',
+registerBlockType( metadata, {
 	icon: BlockIcon,
-	attributes: {
-		address: {
-			type: 'string',
-			default: '',
-		},
-		height: {
-			type: 'string',
-			default: '450',
-		},
-		latitude: {
-			type: 'number',
-			default: 51.48762585296625,
-		},
-		longitude: {
-			type: 'number',
-			default: -0.1326724377053381,
-		},
-		rotation: {
-			type: 'number',
-			default: 0,
-		},
-		zoom: {
-			type: 'number',
-			default: 15,
-		},
+	attributes: { ...metadata.attributes,
 		mapType: {
 			type: 'string',
 			default: Map.MapTypes.Standard,
-		},
-		showsMapTypeControl: {
-			type: 'boolean',
-			default: true,
-		},
-		isRotationEnabled: {
-			type: 'boolean',
-			default: true,
 		},
 		showsCompass: {
 			type: 'string',
 			default: FeatureVisibility.Adaptive,
 		},
-		isZoomEnabled: {
-			type: 'boolean',
-			default: true,
-		},
-		showsZoomControl: {
-			type: 'boolean',
-			default: true,
-		},
-		isScrollEnabled: {
-			type: 'boolean',
-			default: true,
-		},
 		showsScale: {
 			type: 'string',
 			default: FeatureVisibility.Adaptive,
-		},
-		markers: {
-			type: 'array',
-			default: [],
-		},
-	},
-	example: {
-		attributes: {
-			latitude: 51.48762585296625,
-			longitude: -0.1326724377053381,
-		},
-	},
-	supports: {
-		align: [ 'wide', 'full' ],
-		html: false,
+		}
 	},
 	edit: MapsBlockAppleEdit,
 	save: MapsBlockAppleSave,

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ const { Map, FeatureVisibility } = mapkit;
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -19,7 +18,8 @@ import metadata from './../block.json';
 
 registerBlockType( metadata, {
 	icon: BlockIcon,
-	attributes: { ...metadata.attributes,
+	attributes: {
+		...metadata.attributes,
 		mapType: {
 			type: 'string',
 			default: Map.MapTypes.Standard,
@@ -31,7 +31,7 @@ registerBlockType( metadata, {
 		showsScale: {
 			type: 'string',
 			default: FeatureVisibility.Adaptive,
-		}
+		},
 	},
 	edit: MapsBlockAppleEdit,
 	save: MapsBlockAppleSave,

--- a/style.css
+++ b/style.css
@@ -1,2 +1,0 @@
-.wp-block-tenup-maps-block-apple {
-}


### PR DESCRIPTION
### Description of the Change

Enqueue map assets only when being used / Clean up unused assets

### Alternate Designs

None.

### Benefits

It will optimize page load times by only enqueuing assets when required.

### Possible Drawbacks

None.

### Verification Process

- Cross check the maps settings page and make sure only the required js/css files for the particular settings page is loading.
- Cross check the post edit screen with Gutenberg enabled to make sure no frontend related map scripts are being loaded.
- Cross check frontend of the site to ensure only on posts that have apple maps block, the maps assets are being loaded.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

None.

### Changelog Entry

Enqueue map assets only when being used / Clean up unused assets
