### PR TITLE
fix remove orign restriction in local env's to allow for proxied domains

### DIFF
--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -89,6 +89,10 @@ function get_jwt() {
 		'origin' => get_fqdn_from_url( get_site_url() ),
 	];
 
+	if ( wp_get_environment_type() === 'local' ) {
+		unset( $body['origin'] );
+	}
+
 	$payload = encode( wp_json_encode( $header ) ) . '.' . encode( wp_json_encode( $body ) );
 
 	$key = openssl_pkey_get_private( $private_key );

--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -89,6 +89,9 @@ function get_jwt() {
 		'origin' => get_fqdn_from_url( get_site_url() ),
 	];
 
+	// exlude the origin restriction from the JWT for local environemts
+	// this is to allow tools like wp-env or browsersync to work since the url
+	// is not the same as the site url.
 	if ( wp_get_environment_type() === 'local' ) {
 		unset( $body['origin'] );
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->
Add a check for the environment to conditionally unset the `origin` restriction of the JWT auth token for local environments.
### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Because of this change it is possible to use browsersync or tools like `wp-env` for local environment where the local development URL is proxied and therefore does not match the `get_site_url()`

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
Navigate to the block settings page under "Settings" -> "Block for Apple Maps" and enter the Mapkit Credentials. When using a url that does not match the site url. When the environment type is defined it will now work :) 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Added exclusion of origin restriction on local environments. 