### PR TITLE
Turn off autoComplete for the search input field.

### DIFF
--- a/src/Settings/LocationSettings.js
+++ b/src/Settings/LocationSettings.js
@@ -63,6 +63,7 @@ export default function LocationSettings(props) {
 					label={__('Search for a Location', 'maps-block-apple')}
 					value={searchString}
 					onChange={handleSearchStringChange}
+					autoComplete='off'
 				/>
 				<SearchResults
 					map={map}


### PR DESCRIPTION
Native browser suggestion pop up can cover the Search results, this PR fixes that issue by disabling the `autoComplete` for the input.

![image](https://user-images.githubusercontent.com/5423135/151342098-828b8c28-d9b3-483c-a808-35cfddb16654.png)
