### PR TITLE
Added support for custom marker icon.

### DIFF
--- a/block.json
+++ b/block.json
@@ -88,5 +88,6 @@
   },
   "editorScript":"maps-block-apple-block",
   "viewScript":"maps-block-apple-frontend",
-  "script": "apple-mapkit-js"
+  "script": "apple-mapkit-js",
+  "editorStyle": "file:build/index.css"
 }

--- a/src/components/AppleMap.js
+++ b/src/components/AppleMap.js
@@ -9,8 +9,16 @@ class AppleMap {
 		this.markerElements =
 			this.element.querySelectorAll('.marker-annotation');
 		this.markers = [...this.markerElements].map((markerElement) => {
-			const { latitude, longitude, title, subtitle, color, glyphColor } =
-				markerElement.dataset;
+			const {
+				latitude,
+				longitude,
+				title,
+				subtitle,
+				color,
+				glyphColor,
+				glyphImage,
+			} = markerElement.dataset;
+
 			return {
 				latitude: Number(latitude),
 				longitude: Number(longitude),
@@ -18,6 +26,7 @@ class AppleMap {
 				subtitle: subtitle || '',
 				color: color || null,
 				glyphColor: glyphColor || null,
+				glyphImage: glyphImage || null,
 			};
 		});
 
@@ -97,13 +106,13 @@ class AppleMap {
 				color,
 				glyphColor,
 				glyphText,
+				glyphImage,
 			} = item;
 			const position = new this.mapkit.Coordinate(
 				Number(latitude),
 				Number(longitude)
 			);
-
-			const marker = new this.mapkit.MarkerAnnotation(position, {
+			const markerAnnotationOptions = {
 				title,
 				subtitle: subtitle || null,
 				titleVisibility:
@@ -114,7 +123,15 @@ class AppleMap {
 				glyphColor: glyphColor || 'white',
 				glyphText: glyphText || '',
 				draggable: !!this.isEditor,
-			});
+			};
+			// Use custom glyph image if provided.
+			if (glyphImage) {
+				markerAnnotationOptions.glyphImage = { 1: glyphImage };
+			}
+			const marker = new this.mapkit.MarkerAnnotation(
+				position,
+				markerAnnotationOptions
+			);
 
 			if (this.setAttributes) {
 				marker.addEventListener('drag-end', (event) => {

--- a/src/components/EditMarker.js
+++ b/src/components/EditMarker.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import LocationInfo from './LocationInfo';
+import MarkerIconUpload from './MarkerIconUpload';
 
 export default function EditMarker(props) {
 	const { marker, remove, update } = props;
@@ -62,6 +63,7 @@ export default function EditMarker(props) {
 				colors={availableColors}
 				onChange={(value) => update({ ...marker, glyphColor: value })}
 			/>
+			<MarkerIconUpload marker={marker} update={update} />
 			<PanelRow>
 				<LocationInfo
 					latitude={marker.latitude}

--- a/src/components/MarkerIconUpload.js
+++ b/src/components/MarkerIconUpload.js
@@ -1,0 +1,83 @@
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+
+export default function MarkerIconUpload(props) {
+	const { marker, update } = props;
+	const ALLOWED_MEDIA_TYPES = ['image'];
+	const onUpdateImage = (media) => {
+		update({
+			...marker,
+			glyphImageId: media.id,
+			glyphImage: media.url,
+		});
+	};
+	const onRemoveImage = () => {
+		update({
+			...marker,
+			glyphImageId: undefined,
+			glyphImage: undefined,
+		});
+	};
+
+	return (
+		<div className="maps-block-apple-marker-uploader">
+			<MediaUploadCheck>
+				<label htmlFor="marker-icon-control">
+					{__('Marker Icon', 'maps-block-apple')}
+				</label>
+				<MediaUpload
+					allowedTypes={ALLOWED_MEDIA_TYPES}
+					render={({ open }) => (
+						<Button
+							className={
+								!marker.glyphImageId
+									? 'editor-post-featured-image__toggle'
+									: 'editor-post-featured-image__preview'
+							}
+							onClick={open}
+						>
+							{!marker.glyphImageId &&
+								__('Choose an icon', 'maps-block-apple')}
+							{marker.glyphImageId && marker.glyphImage && (
+								<img
+									src={marker.glyphImage}
+									alt={__('Marker icon', 'maps-block-apple')}
+								/>
+							)}
+						</Button>
+					)}
+					onSelect={onUpdateImage}
+					value={marker.glyphImageId}
+				/>
+			</MediaUploadCheck>
+			{!!marker.glyphImageId && (
+				<MediaUploadCheck>
+					{marker.glyphImage && (
+						<MediaUpload
+							onSelect={onUpdateImage}
+							allowedTypes={ALLOWED_MEDIA_TYPES}
+							render={({ open }) => (
+								<Button
+									onClick={open}
+									variant="secondary"
+									className="replace-marker-icon"
+								>
+									{__('Replace icon', 'maps-block-apple')}
+								</Button>
+							)}
+						/>
+					)}
+					<Button
+						className="remove-marker-icon"
+						onClick={onRemoveImage}
+						variant="link"
+						isDestructive
+					>
+						{__('Remove icon', 'maps-block-apple')}
+					</Button>
+				</MediaUploadCheck>
+			)}
+		</div>
+	);
+}

--- a/src/components/MarkerIconUpload.js
+++ b/src/components/MarkerIconUpload.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, BaseControl } from '@wordpress/components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 
 export default function MarkerIconUpload(props) {
@@ -22,62 +22,67 @@ export default function MarkerIconUpload(props) {
 
 	return (
 		<div className="maps-block-apple-marker-uploader">
-			<MediaUploadCheck>
-				<label htmlFor="marker-icon-control">
-					{__('Marker Icon', 'maps-block-apple')}
-				</label>
-				<MediaUpload
-					allowedTypes={ALLOWED_MEDIA_TYPES}
-					render={({ open }) => (
-						<Button
-							className={
-								!marker.glyphImageId
-									? 'editor-post-featured-image__toggle'
-									: 'editor-post-featured-image__preview'
-							}
-							onClick={open}
-						>
-							{!marker.glyphImageId &&
-								__('Choose an icon', 'maps-block-apple')}
-							{marker.glyphImageId && marker.glyphImage && (
-								<img
-									src={marker.glyphImage}
-									alt={__('Marker icon', 'maps-block-apple')}
-								/>
-							)}
-						</Button>
-					)}
-					onSelect={onUpdateImage}
-					value={marker.glyphImageId}
-				/>
-			</MediaUploadCheck>
-			{!!marker.glyphImageId && (
+			<BaseControl
+				id="marker-icon-control"
+				label={__('Marker Icon', 'maps-block-apple')}
+			>
 				<MediaUploadCheck>
-					{marker.glyphImage && (
-						<MediaUpload
-							onSelect={onUpdateImage}
-							allowedTypes={ALLOWED_MEDIA_TYPES}
-							render={({ open }) => (
-								<Button
-									onClick={open}
-									variant="secondary"
-									className="replace-marker-icon"
-								>
-									{__('Replace icon', 'maps-block-apple')}
-								</Button>
-							)}
-						/>
-					)}
-					<Button
-						className="remove-marker-icon"
-						onClick={onRemoveImage}
-						variant="link"
-						isDestructive
-					>
-						{__('Remove icon', 'maps-block-apple')}
-					</Button>
+					<MediaUpload
+						allowedTypes={ALLOWED_MEDIA_TYPES}
+						render={({ open }) => (
+							<Button
+								className={
+									!marker.glyphImageId
+										? 'editor-post-featured-image__toggle'
+										: 'editor-post-featured-image__preview'
+								}
+								onClick={open}
+							>
+								{!marker.glyphImageId &&
+									__('Choose an icon', 'maps-block-apple')}
+								{marker.glyphImageId && marker.glyphImage && (
+									<img
+										src={marker.glyphImage}
+										alt={__(
+											'Marker icon',
+											'maps-block-apple'
+										)}
+									/>
+								)}
+							</Button>
+						)}
+						onSelect={onUpdateImage}
+						value={marker.glyphImageId}
+					/>
 				</MediaUploadCheck>
-			)}
+				{!!marker.glyphImageId && (
+					<MediaUploadCheck>
+						{marker.glyphImage && (
+							<MediaUpload
+								onSelect={onUpdateImage}
+								allowedTypes={ALLOWED_MEDIA_TYPES}
+								render={({ open }) => (
+									<Button
+										onClick={open}
+										variant="secondary"
+										className="replace-marker-icon"
+									>
+										{__('Replace icon', 'maps-block-apple')}
+									</Button>
+								)}
+							/>
+						)}
+						<Button
+							className="remove-marker-icon"
+							onClick={onRemoveImage}
+							variant="link"
+							isDestructive
+						>
+							{__('Remove icon', 'maps-block-apple')}
+						</Button>
+					</MediaUploadCheck>
+				)}
+			</BaseControl>
 		</div>
 	);
 }

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+const { Map, FeatureVisibility } = mapkit;
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+
+export default [
+	{
+		attributes: {
+			...metadata.attributes,
+			mapType: {
+				type: 'string',
+				default: Map.MapTypes.Standard,
+			},
+			showsCompass: {
+				type: 'string',
+				default: FeatureVisibility.Adaptive,
+			},
+			showsScale: {
+				type: 'string',
+				default: FeatureVisibility.Adaptive,
+			},
+		},
+		save(props) {
+			const {
+				attributes: {
+					mapType,
+					height,
+					latitude,
+					longitude,
+					rotation,
+					zoom,
+					showsMapTypeControl,
+					isRotationEnabled,
+					showsCompass,
+					isZoomEnabled,
+					showsZoomControl,
+					isScrollEnabled,
+					showsScale,
+					markers,
+				},
+			} = props;
+
+			const blockProps = useBlockProps.save();
+
+			return (
+				<div
+					{...blockProps}
+					data-map-type={mapType}
+					data-latitude={latitude}
+					data-longitude={longitude}
+					data-rotation={rotation}
+					data-zoom={zoom}
+					data-shows-map-type-control={showsMapTypeControl}
+					data-is-rotation-enabled={isRotationEnabled}
+					data-shows-compass={showsCompass}
+					data-is-zoom-enabled={isZoomEnabled}
+					data-shows-zoom-control={showsZoomControl}
+					data-is-scroll-enabled={isScrollEnabled}
+					data-shows-scale={showsScale}
+					style={{ height: `${height}px` }}
+				>
+					{markers.map((marker, index) => (
+						<div
+							key={index}
+							className={'marker-annotation'}
+							data-latitude={marker.latitude}
+							data-longitude={marker.longitude}
+							data-title={marker.title}
+							data-subtitle={marker.subtitle}
+							data-color={marker.color}
+							data-glyph-color={marker.glyphColor}
+						/>
+					))}
+				</div>
+			);
+		},
+	},
+];

--- a/src/edit.js
+++ b/src/edit.js
@@ -22,6 +22,8 @@ import BlockIcon from './block-icon';
 import { ResizableMap } from './components/ResizableMap';
 import { store as mapsBlockAppleStore } from './store';
 
+import './editor.scss';
+
 const Map = memo((props) => {
 	const { map, isAuthenticated, clientId, setAttributes, setMap, mapkit } =
 		props;

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -1,0 +1,7 @@
+div.maps-block-apple-marker-uploader {
+	button.replace-marker-icon,
+	button.remove-marker-icon{
+		display: block;
+		margin-top: 1em;
+	}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import MapsBlockAppleEdit from './edit';
 import MapsBlockAppleSave from './save';
 import BlockIcon from './block-icon';
 import metadata from './../block.json';
+import deprecated from './deprecated';
 
 registerBlockType(metadata, {
 	icon: BlockIcon,
@@ -36,4 +37,5 @@ registerBlockType(metadata, {
 	},
 	edit: MapsBlockAppleEdit,
 	save: MapsBlockAppleSave,
+	deprecated,
 });

--- a/src/save.js
+++ b/src/save.js
@@ -49,6 +49,7 @@ export default function MapsBlockAppleSave(props) {
 					data-subtitle={marker.subtitle}
 					data-color={marker.color}
 					data-glyph-color={marker.glyphColor}
+					data-glyph-image={marker.glyphImage}
 				/>
 			))}
 		</div>


### PR DESCRIPTION
### Description of the Change
As requested in #92, this PR adds support for the custom marker icon. Users can upload an icon image from the marker settings, Please check the following screenshot for more information. 

![Screenshot 2022-11-01 at 4 28 41 PM](https://user-images.githubusercontent.com/10613171/199219975-850fdee2-b737-47a2-a873-63abf42433b6.png)


Closes #92

### How to test the Change
1. Add Apple Maps block to the editor
2. Add a marker on the map.
3. Go to maker settings to upload icon image
4. Verify and confirm marker start showing the icon image uploaded by you (instead of default pin icon). 

### Changelog Entry
> Added - support for custom marker icon.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @dinhtungdu @fabiankaegy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
