### PR TITLE
Bump WordPress "tested up to" version 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu
 Tags:              apple maps, map block, block
 Requires at least: 5.8
-Tested up to:      6.0
+Tested up to:      6.1
 Requires PHP:      5.6
 Stable tag:        1.0.3
 License:           GPLv2 or later


### PR DESCRIPTION
### Description of the Change
Performed tests with WordPress core 6.1, Twenty Twenty Three theme

Tests performed:
- [x] Plugin activate/deactivate on WP6.1
- [x] Save settings with Apple map keys
- [x] Tested the Apple Maps block, and it's working fine.

Closes #140 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.1



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
