### PR TITLE
Add `margin` support to the Apple Maps Block 

### DIFF
--- a/block.json
+++ b/block.json
@@ -84,6 +84,9 @@
       "wide",
       "full"
     ],
+    "spacing": {
+      "margin": true
+    },
     "html":false
   },
   "editorScript":"maps-block-apple-block",

--- a/src/save.js
+++ b/src/save.js
@@ -20,7 +20,11 @@ export default function MapsBlockAppleSave(props) {
 		},
 	} = props;
 
-	const blockProps = useBlockProps.save();
+	const blockProps = useBlockProps.save({
+		style: {
+			height: `${height}px`,
+		},
+	});
 
 	return (
 		<div
@@ -37,7 +41,6 @@ export default function MapsBlockAppleSave(props) {
 			data-shows-zoom-control={showsZoomControl}
 			data-is-scroll-enabled={isScrollEnabled}
 			data-shows-scale={showsScale}
-			style={{ height: `${height}px` }}
 		>
 			{markers.map((marker, index) => (
 				<div


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Add the ability to change the margin of the Map.

https://user-images.githubusercontent.com/20684594/213981287-d19da433-d47d-475c-bc8b-64264d114130.mp4



<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #156

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Enter a Map anywhere on a theme that has the margin controls enabled in `theme.json`. You can use any of the Default themes like `twentytwentythree` which have this by default.

Once you've inserted the map you can select the Margin control under the "Dimensions" panel in the settings sidebar

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Ability to control margin of map


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
