### PR TITLE
Fixed: Map js loading everywhere

### DIFF
--- a/block.json
+++ b/block.json
@@ -91,6 +91,5 @@
   },
   "editorScript":"maps-block-apple-block",
   "viewScript":"maps-block-apple-frontend",
-  "script": "apple-mapkit-js",
   "editorStyle": "file:build/index.css"
 }

--- a/includes/block-assets.php
+++ b/includes/block-assets.php
@@ -49,7 +49,7 @@ function register_block_assets() {
 	wp_register_script(
 		'maps-block-apple-block',
 		MAPS_BLOCK_APPLE_URL . "build/$block_file_name.js",
-		$block_dependencies['dependencies'],
+		array_merge( $block_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
 		$block_dependencies['version'],
 		false
 	);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Map js library was loading everywhere. Now it is fixed.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #147 

### How to test the Change
- Create a page or post
- Add Apple Map block
- Save and visit
- Open network log and make sure `https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js` is loading
- Now edit the post, remove the map block, save and visit again
- Now you should see the library is not loading anymore. Previously it used load even though there is no map block in the post. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Mapkit js loading everywhere in frontend despite no Map block there is

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jayedul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
