### PR TITLE
Incorrect build branch target fix

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,7 +6,7 @@ on:
       - develop
 jobs:
   build: 
-    uses: 10up/maps-block-apple/.github/workflows/build-release-zip.yml@update/151 # TODO: Update this to develop branch.
+    uses: 10up/maps-block-apple/.github/workflows/build-release-zip.yml@develop
   cypress:
     needs: build
     name: ${{ matrix.core.name }}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
E2E target build branch was supposed to be changed to `develop` before merging #163  