### PR TITLE
Ensure that the Apple Maps block works fine in WP 6.4

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -222,12 +222,14 @@ export default function MapsBlockAppleEdit(props) {
 							'maps-block-apple'
 						)}
 						icon={BlockIcon}
-						instructions={
-							<IsAdmin
-								fallback={__(
-									'Sorry, you are not allowed to do that. Please talk to your Administrator.'
-								)}
-							>
+						isColumnLayout={true}
+					>
+						<IsAdmin
+							fallback={__(
+								'Sorry, you are not allowed to do that. Please talk to your Administrator.'
+							)}
+						>
+							<div style={{ marginBottom: '1em' }}>
 								{__(
 									'In order to include an Apple Map on your website you need to confirm your MapKit credentials below. Here is documentation on how to get those credentials: ',
 									'maps-block-apple'
@@ -241,12 +243,8 @@ export default function MapsBlockAppleEdit(props) {
 										'Instructions for creating your MapKit credentials.',
 										'maps-block-apple'
 									)}
-								</a>{' '}
-							</IsAdmin>
-						}
-						isColumnLayout={true}
-					>
-						<IsAdmin>
+								</a>
+							</div>
 							<EditAuthForm />
 						</IsAdmin>
 					</Placeholder>

--- a/src/edit.js
+++ b/src/edit.js
@@ -226,7 +226,8 @@ export default function MapsBlockAppleEdit(props) {
 					>
 						<IsAdmin
 							fallback={__(
-								'Sorry, you are not allowed to do that. Please talk to your Administrator.'
+								'Sorry, you are not allowed to do that. Please talk to your Administrator.',
+								'maps-block-apple'
 							)}
 						>
 							<div style={{ marginBottom: '1em' }}>


### PR DESCRIPTION
### Description of the Change
PR fixes the Apple Maps block error in WP 6.4-beta2 when MapKit Credentials are not configured. 

For more information on the root cause of the issue please check the issue description [here](https://github.com/10up/maps-block-apple/issues/182#issue-1925773428).

![image](https://github.com/10up/maps-block-apple/assets/10613171/c5cd30b3-f2f9-4f73-9a32-f9bb1e2c0e81)


Closes #182

### How to test the Change
1. Install and activate the plugin on WP 6.4-beta-2
2. Keep Mapkit js credentials blank
3. Go to create post/page and add "Apple Maps" block
4. Verify Apple Maps block working fine without any errors.

### Changelog Entry
> Fixed - Ensure that the Apple Maps block works fine in WordPress 6.4.


### Credits
Props @iamdharmesh @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
