### PR TITLE
Bump WordPress "tested up to" version 6.4 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu, jeffpaul
 Tags:              apple maps, map block, block
 Requires at least: 5.8
-Tested up to:      6.3
+Tested up to:      6.4
 Requires PHP:      7.4
 Stable tag:        1.1.2
 License:           GPLv2 or later


### PR DESCRIPTION
Ports #190 to `trunk` to hopefully trigger the Readme action and push the update to WP.org.