### PR TITLE
Bump WordPress "tested up to" version 6.5

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.8'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > An Apple Maps block for the WordPress block editor (Gutenberg).
 
-[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/maps-block-apple.svg)](https://github.com/10up/maps-block-apple/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/maps-block-apple?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/maps-block-apple.svg)](https://github.com/10up/maps-block-apple/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/maps-block-apple.svg)](https://github.com/10up/maps-block-apple/releases/latest) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/maps-block-apple?label=WordPress) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/maps-block-apple.svg)](https://github.com/10up/maps-block-apple/blob/develop/LICENSE.md)
 
 ## Overview
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "version": "1.0.1",
   "type": "wordpress-plugin",
   "homepage": "https://10up.com",
-  "license": "GPLv2 or later",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "10up",

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -8,8 +8,8 @@
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com
- * License:           GPLv2 or later
- * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
+ * License:           GPL-2.0-or-later
+ * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
  * Text Domain:       maps-block-apple
  *
  * @package           tenup\Maps_Block_Apple

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/maps-block-apple
  * Description:       An Apple Maps block for the WordPress block editor (Gutenberg).
  * Version:           1.1.3
- * Requires at least: 5.8
+ * Requires at least: 6.3
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://10up.com",
     "role": "developer"
   },
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "scripts": {
     "build": "wp-scripts build src/index.js src/frontend.js src/admin-settings.js",
     "check-engines": "wp-scripts check-engines",

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,7 @@
 === Block for Apple Maps ===
 Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu, jeffpaul
 Tags:              apple maps, map block, block
-Requires at least: 5.8
-Tested up to:      6.4
-Requires PHP:      7.4
+Tested up to:      6.5
 Stable tag:        1.1.3
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu, jeffpaul
 Tags:              apple maps, map block, block
 Tested up to:      6.5
 Stable tag:        1.1.3
-License:           GPLv2 or later
-License URI:       http://www.gnu.org/licenses/gpl-2.0.html
+License:           GPL-2.0-or-later
+License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 
 An Apple Maps block for the WordPress block editor (Gutenberg).
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP minimum to 6.3, the tested-up-to to 6.5, and corrects licensing to the `GPL-2.0-or-later` standard reference.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #203.

### How to test the Change
Run e2e tests and see that min/max versions pass.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.5.
> Changed - Bump WordPress minimum supported version to 6.3.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @QAharshalkadu, @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
