### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin integrates Apple's [MapKit JS](https://developer.apple.com/maps/mapk
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org/) 5.8+
+* [WordPress](http://wordpress.org/) 6.4+
 * Due to the requirements applied by Apple to use Apple Maps ([MapkitJS](https://developer.apple.com/maps/mapkitjs/)), Apple Maps for WordPress requires an [Apple Developer](https://developer.apple.com/) [account](https://developer.apple.com/account/) and enrollment within the [Apple Developer Program](https://developer.apple.com/programs/).
 
 ## Installation

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/maps-block-apple
  * Description:       An Apple Maps block for the WordPress block editor (Gutenberg).
  * Version:           1.1.3
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,14 @@
     "": {
       "name": "maps-block-apple",
       "version": "1.1.3",
-      "license": "GPL-2.0-only",
+      "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "@10up/cypress-wp-utils": "^0.2.0",
-        "@wordpress/env": "^8.7.0",
+        "@10up/cypress-wp-utils": "^0.3.0",
+        "@wordpress/env": "^10.2.0",
         "@wordpress/eslint-plugin": "^10.0.1",
         "@wordpress/scripts": "^27.5.0",
-        "cypress": "^13.2.0",
-        "cypress-mochawesome-reporter": "^3.6.0",
+        "cypress": "^13.13.0",
+        "cypress-mochawesome-reporter": "^3.8.2",
         "mochawesome-json-to-md": "^0.7.2"
       },
       "engines": {
@@ -22,9 +22,10 @@
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.2.0",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.3.0.tgz",
+      "integrity": "sha512-iMjvca50TerMCY9M9vL0FIE+80ye5YohaQp3XvhgUgQdc4LS51X2fH+lhdb0uRmBTiUQcISazEvWGJxV7DeTbw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
@@ -4797,13 +4798,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "8.7.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-EToZYPGXpl42Asw3bxpX8aKmHfRUdGxKPjQ9CHZVQoTAL27Af4FyjyGnepsnDpnYdIeI8VPb2S3k2NL/1+fpIA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -4816,6 +4818,10 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/env/node_modules/ansi-styles": {
@@ -8370,20 +8376,20 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.2.0",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
+      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -8401,7 +8407,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -8415,7 +8421,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -8427,9 +8433,10 @@
       }
     },
     "node_modules/cypress-mochawesome-reporter": {
-      "version": "3.6.0",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.8.2.tgz",
+      "integrity": "sha512-oJZkNzhNmN9ZD+LmZyFuPb8aWaIijyHyqYh52YOBvR6B6ckfJNCHP3A98a+/nG0H4t46CKTNwo+wNpMa4d2kjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^10.0.1",
         "fs-extra": "^10.0.1",
@@ -8470,11 +8477,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "18.17.18",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -9132,11 +9134,27 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -21122,14 +21140,12 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -22657,7 +22673,9 @@
   },
   "dependencies": {
     "@10up/cypress-wp-utils": {
-      "version": "0.2.0",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.3.0.tgz",
+      "integrity": "sha512-iMjvca50TerMCY9M9vL0FIE+80ye5YohaQp3XvhgUgQdc4LS51X2fH+lhdb0uRmBTiUQcISazEvWGJxV7DeTbw==",
       "dev": true
     },
     "@ampproject/remapping": {
@@ -25981,12 +25999,14 @@
       }
     },
     "@wordpress/env": {
-      "version": "8.7.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-EToZYPGXpl42Asw3bxpX8aKmHfRUdGxKPjQ9CHZVQoTAL27Af4FyjyGnepsnDpnYdIeI8VPb2S3k2NL/1+fpIA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -28381,18 +28401,19 @@
       }
     },
     "cypress": {
-      "version": "13.2.0",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
+      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -28410,7 +28431,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -28424,15 +28445,11 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.17.18",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "dev": true,
@@ -28514,7 +28531,9 @@
       }
     },
     "cypress-mochawesome-reporter": {
-      "version": "3.6.0",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.8.2.tgz",
+      "integrity": "sha512-oJZkNzhNmN9ZD+LmZyFuPb8aWaIijyHyqYh52YOBvR6B6ckfJNCHP3A98a+/nG0H4t46CKTNwo+wNpMa4d2kjA==",
       "dev": true,
       "requires": {
         "commander": "^10.0.1",
@@ -28896,8 +28915,21 @@
       }
     },
     "docker-compose": {
-      "version": "0.22.2",
-      "dev": true
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "requires": {
+        "yaml": "^2.2.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+          "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+          "dev": true
+        }
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -37173,11 +37205,10 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.2.1",
-      "dev": true,
-      "requires": {
-        "rimraf": "^3.0.0"
-      }
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "node": ">=12.0"
   },
   "devDependencies": {
-    "@10up/cypress-wp-utils": "^0.2.0",
-    "@wordpress/env": "^8.7.0",
+    "@10up/cypress-wp-utils": "^0.3.0",
+    "@wordpress/env": "^10.2.0",
     "@wordpress/eslint-plugin": "^10.0.1",
     "@wordpress/scripts": "^27.5.0",
-    "cypress": "^13.2.0",
-    "cypress-mochawesome-reporter": "^3.6.0",
+    "cypress": "^13.13.0",
+    "cypress-mochawesome-reporter": "^3.8.2",
     "mochawesome-json-to-md": "^0.7.2"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Block for Apple Maps ===
 Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu, jeffpaul
 Tags:              apple maps, map block, block
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        1.1.3
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to 6.6, the minimum to 6.4, and updates the e2e tests to using 6.4 as the minimum as well.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #217.

### How to test the Change
Use Plugin ZIP action to get version from this PR and run through critical flows, otherwise review results of e2e tests.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum supported version to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
