### PR TITLE
Bump tested upto version and minimum wp version

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This plugin integrates Apple's [MapKit JS](https://developer.apple.com/maps/mapk
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org/) 6.4+
+* [WordPress](http://wordpress.org/) 6.5+
 * Due to the requirements applied by Apple to use Apple Maps ([MapkitJS](https://developer.apple.com/maps/mapkitjs/)), Apple Maps for WordPress requires an [Apple Developer](https://developer.apple.com/) [account](https://developer.apple.com/account/) and enrollment within the [Apple Developer Program](https://developer.apple.com/programs/).
 
 ## Installation

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/maps-block-apple
  * Description:       An Apple Maps block for the WordPress block editor (Gutenberg).
  * Version:           1.1.4
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Block for Apple Maps ===
 Contributors:      10up, helen, welcher, fabiankaegy, dinhtungdu, jeffpaul
 Tags:              apple maps, map block, block
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        1.1.4
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to 6.7, the minimum to 6.5, and updates the e2e tests to using 6.5 as the minimum as well.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #228 

### How to test the Change
Use Plugin ZIP action to get version from this PR and run through critical flows, otherwise review results of e2e tests.

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.7.
> Changed - Bump WordPress minimum supported version to 6.5.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md @jeffpaul @mehidi258 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
