### PR TITLE
Fix block crash when Apple Maps credentials are missing.

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -81,18 +81,17 @@ export default function MapsBlockAppleEdit(props) {
 	 */
 	const checkCredentials = async () => {
 		try {
-			const response = await apiFetch({ path: 'MapsBlockApple/v1/GetJWT' });
-			// If the endpoint returns a JWT, treat as authenticated.
+			const response = await apiFetch({
+				path: 'MapsBlockApple/v1/GetJWT',
+			});
 			if (response && response.jwt) {
 				return true;
-			} else {
-				setIsLoading(false);
-				updateAuthenticationStatus(false);
-				return false;
 			}
+
+			setIsLoading(false);
+			updateAuthenticationStatus(false);
+			return false;
 		} catch (error) {
-			// If the endpoint returns an error, treat as unauthenticated.
-			console.error(error);
 			setIsLoading(false);
 			updateAuthenticationStatus(false);
 			return false;

--- a/src/edit.js
+++ b/src/edit.js
@@ -84,7 +84,7 @@ export default function MapsBlockAppleEdit(props) {
 			const response = await apiFetch({
 				path: 'MapsBlockApple/v1/GetJWT',
 			});
-			if (response && response.jwt) {
+			if (response) {
 				return true;
 			}
 

--- a/src/edit.js
+++ b/src/edit.js
@@ -13,6 +13,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 import { AppleMapEdit } from './components/AppleMap';
 import EditAuthForm from './components/EditAuthForm';
@@ -74,6 +75,33 @@ export default function MapsBlockAppleEdit(props) {
 
 	const { updateAuthenticationStatus } = useDispatch(mapsBlockAppleStore);
 	const { toggleSelection } = useDispatch(blockEditorStore);
+
+	/**
+	 * Check if the credentials exist.
+	 */
+	const checkCredentials = async () => {
+		try {
+			const settings = await apiFetch({ path: 'wp/v2/settings' });
+			const hasCredentials =
+				settings.maps_block_apple &&
+				settings.maps_block_apple.private_key &&
+				settings.maps_block_apple.key_id &&
+				settings.maps_block_apple.team_id;
+
+			if (!hasCredentials) {
+				setIsLoading(false);
+				updateAuthenticationStatus(false);
+				return;
+			}
+
+			// Credentials exist, proceed with normal initialization
+			return true;
+		} catch (error) {
+			setIsLoading(false);
+			updateAuthenticationStatus(false);
+			return false;
+		}
+	};
 
 	/**
 	 * setup the initial authentication of mapkit and setup all the event listeners
@@ -144,8 +172,11 @@ export default function MapsBlockAppleEdit(props) {
 		/**
 		 * handleMapkitReInitialization
 		 */
-		const InitializeMapkit = () => {
-			AppleMapEdit.authenticateMap(localMapkit);
+		const InitializeMapkit = async () => {
+			const hasValidCredentials = await checkCredentials();
+			if (hasValidCredentials) {
+				AppleMapEdit.authenticateMap(localMapkit);
+			}
 		};
 		localMapkit.addEventListener('reinitialize', InitializeMapkit);
 

--- a/src/edit.js
+++ b/src/edit.js
@@ -81,22 +81,18 @@ export default function MapsBlockAppleEdit(props) {
 	 */
 	const checkCredentials = async () => {
 		try {
-			const settings = await apiFetch({ path: 'wp/v2/settings' });
-			const hasCredentials =
-				settings.maps_block_apple &&
-				settings.maps_block_apple.private_key &&
-				settings.maps_block_apple.key_id &&
-				settings.maps_block_apple.team_id;
-
-			if (!hasCredentials) {
+			const response = await apiFetch({ path: 'MapsBlockApple/v1/GetJWT' });
+			// If the endpoint returns a JWT, treat as authenticated.
+			if (response && response.jwt) {
+				return true;
+			} else {
 				setIsLoading(false);
 				updateAuthenticationStatus(false);
-				return;
+				return false;
 			}
-
-			// Credentials exist, proceed with normal initialization
-			return true;
 		} catch (error) {
+			// If the endpoint returns an error, treat as unauthenticated.
+			console.error(error);
 			setIsLoading(false);
 			updateAuthenticationStatus(false);
 			return false;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

This PR fixes the issue where the Apple Maps block would crash when no credentials were configured instead of showing the credentials form. 

Key changes:

- Added proper credentials check before MapKit initialization
- Ensured block transitions from loading state to credentials form when no credentials exist

Closes #232 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Create a new post
2. Add the Apple Maps block
3. Verify that instead of crashing, you see the credentials form with instructions

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Fixed - Block crash when no Apple Maps credentials are configured, now properly shows credentials form

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @elvismdev 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
