### PR TITLE
Add security bug reporting information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](
 
 ![Block marker settings](.wordpress-org/screenshot-2.png "Example of Apple Maps block showing Marker settings in the new WordPress editor")
 
+### Where do I report security bugs found in this plugin?
+
+Please report security bugs found in the source code of the Block for Apple Maps plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/6c456c3d-5e43-4e4c-a79b-9114c249140e).  The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 ## Support Level
 
 **Stable:** 10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns. We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes. We otherwise intend to keep this tested up to the most recent version of WordPress.

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,10 @@ There is a free daily limit of 250,000 map views and 25,000 service calls per th
 
 Yes, you can track your MapKit JS useage on the [MapKit JS Developer Dashboard](https://maps.developer.apple.com/).  You can also monitor map initializations and service requests in realtime, or see up to a year of activity by day, week, month, or year via the MapKit JS Dashboard.
 
+= Where do I report security bugs found in this plugin? =
+
+Please report security bugs found in the source code of the Block for Apple Maps plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/6c456c3d-5e43-4e4c-a79b-9114c249140e).  The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 == Screenshots ==
 
 1. Block settings


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request adds important security reporting information to the plugin's documentation. Specifically, it provides clear instructions on how to report security vulnerabilities via the Patchstack Vulnerability Disclosure Program.

Documentation and security:

* Added a new section to `readme.txt` explaining how to report security bugs, directing users to use the Patchstack Vulnerability Disclosure Program for responsible disclosure.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Add Patchstack security-reporting FAQ.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
