### PR TITLE
Update 10up/phpcs-composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
   "require": {
     "10up/wp-compat-validation-tool": "dev-trunk"
   },
-  "require-dev": {
-    "10up/phpcs-composer": "dev-master"
-  },
   "scripts": {
     "lint": "./vendor/bin/phpcs",
     "lint-fix": "./vendor/bin/phpcbf --extensions=php .",
@@ -47,5 +44,8 @@
     "installer-paths": {
       "./{$name}/": ["10up/wp-compat-validation-tool"]
     }
+  },
+  "require-dev": {
+    "10up/phpcs-composer": "dev-trunk"
   }
 }

--- a/includes/block-assets.php
+++ b/includes/block-assets.php
@@ -19,14 +19,14 @@ function register_block_assets() {
 	wp_register_style(
 		'maps-block-apple-settings',
 		trailingslashit( MAPS_BLOCK_APPLE_URL ) . 'assets/css/admin-maps-block-apple-settings.css',
-		[],
+		array(),
 		MAPS_BLOCK_APPLE_VERSION
 	);
 
 	/**
 	 * Mapkit Library
 	 */
-	wp_register_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', [], 5, false );
+	wp_register_script( 'apple-mapkit-js', 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js', array(), 5, false );
 
 	/**
 	 * Admin Settings Script
@@ -36,7 +36,7 @@ function register_block_assets() {
 	wp_register_script(
 		'maps-block-apple-settings',
 		MAPS_BLOCK_APPLE_URL . "build/$settings_file_name.js",
-		array_merge( $settings_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
+		array_merge( $settings_dependencies['dependencies'], array( 'apple-mapkit-js' ) ),
 		$settings_dependencies['version'],
 		true
 	);
@@ -49,16 +49,16 @@ function register_block_assets() {
 	wp_register_script(
 		'maps-block-apple-block',
 		MAPS_BLOCK_APPLE_URL . "build/$block_file_name.js",
-		array_merge( $block_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
+		array_merge( $block_dependencies['dependencies'], array( 'apple-mapkit-js' ) ),
 		$block_dependencies['version'],
 		false
 	);
 	wp_localize_script(
 		'maps-block-apple-block',
 		'_mbaData',
-		[
+		array(
 			'settingsURL' => admin_url( 'options-general.php?page=block-for-apple-maps' ),
-		]
+		)
 	);
 
 	/**
@@ -69,13 +69,12 @@ function register_block_assets() {
 	wp_register_script(
 		'maps-block-apple-frontend',
 		MAPS_BLOCK_APPLE_URL . "build/$fe_file_name.js",
-		array_merge( $frontend_dependencies['dependencies'], [ 'apple-mapkit-js' ] ),
+		array_merge( $frontend_dependencies['dependencies'], array( 'apple-mapkit-js' ) ),
 		$frontend_dependencies['version'],
 		false
 	);
 
 	register_block_type( MAPS_BLOCK_APPLE_PATH );
-
 }
 
 add_action( 'enqueue_block_assets', __NAMESPACE__ . '\load_apple_map_script_in_iframe' );

--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -7,8 +7,8 @@
 
 namespace tenup\Maps_Block_Apple;
 
-use \WP_Error as WP_Error;
-use \WP_REST_Response as WP_REST_Response;
+use WP_Error;
+use WP_REST_Response;
 use function tenup\Maps_Block_Apple\Settings\get_setting;
 
 define( 'MAPS_BLOCK_APPLE_VERSION_REST_NAMESPACE', 'MapsBlockApple/v1' );
@@ -23,11 +23,11 @@ function add_endpoints() {
 	register_rest_route(
 		MAPS_BLOCK_APPLE_VERSION_REST_NAMESPACE,
 		'/GetJWT',
-		[
+		array(
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\get_jwt',
 			'permission_callback' => '__return_true',
-		]
+		)
 	);
 }
 
@@ -55,39 +55,39 @@ function get_jwt() {
 	$team_id     = get_setting( 'team_id' );
 
 	if ( ! isset( $private_key ) || '' === $private_key ) {
-		return new WP_Error( 'NoKey', 'Missing Private Key', [ 'status' => 401 ] );
+		return new WP_Error( 'NoKey', 'Missing Private Key', array( 'status' => 401 ) );
 	}
 	if ( ! isset( $key_id ) || '' === $key_id ) {
-		return new WP_Error( 'NoKey', 'Missing Key ID', [ 'status' => 401 ] );
+		return new WP_Error( 'NoKey', 'Missing Key ID', array( 'status' => 401 ) );
 	}
 	if ( ! isset( $team_id ) || '' === $team_id ) {
-		return new WP_Error( 'NoKey', 'Missing Team ID', [ 'status' => 401 ] );
+		return new WP_Error( 'NoKey', 'Missing Team ID', array( 'status' => 401 ) );
 	}
 	if ( 10 !== strlen( $key_id ) ) {
-		return new WP_Error( 'InvalidKey', 'Invalid Key ID', [ 'status' => 401 ] );
+		return new WP_Error( 'InvalidKey', 'Invalid Key ID', array( 'status' => 401 ) );
 	}
 	if ( 10 !== strlen( $team_id ) ) {
-		return new WP_Error( 'InvalidKey', 'Invalid Team ID', [ 'status' => 401 ] );
+		return new WP_Error( 'InvalidKey', 'Invalid Team ID', array( 'status' => 401 ) );
 	}
 	if (
 		0 !== strpos( $private_key, '-----BEGIN PRIVATE KEY-----' )
 		&& ! strpos( $private_key, '-----END PRIVATE KEY-----' )
 	) {
-		return new WP_Error( 'InvalidKey', 'Invalid Private Key', [ 'status' => 401 ] );
+		return new WP_Error( 'InvalidKey', 'Invalid Private Key', array( 'status' => 401 ) );
 	}
 
-	$header = [
+	$header = array(
 		'alg' => 'ES256',
 		'typ' => 'JWT',
 		'kid' => $key_id,
-	];
+	);
 
-	$body = [
+	$body = array(
 		'iss'    => $team_id,
 		'iat'    => time(),
 		'exp'    => time() + 30,
 		'origin' => get_fqdn_from_url( get_site_url() ),
-	];
+	);
 
 	// exlude the origin restriction from the JWT for local environemts
 	// this is to allow tools like wp-env or browsersync to work since the url
@@ -100,11 +100,11 @@ function get_jwt() {
 
 	$key = openssl_pkey_get_private( $private_key );
 	if ( ! $key ) {
-		return new WP_Error( 'InvalidKey', 'Invalid Private Key', [ 'status' => 401 ] );
+		return new WP_Error( 'InvalidKey', 'Invalid Private Key', array( 'status' => 401 ) );
 	}
 
 	if ( ! openssl_sign( $payload, $signature, $key, OPENSSL_ALGO_SHA256 ) ) {
-		return new WP_Error( 'SignError', 'Signing Failed', [ 'status' => 500 ] );
+		return new WP_Error( 'SignError', 'Signing Failed', array( 'status' => 500 ) );
 	}
 
 	$response = $payload . '.' . encode( $signature );

--- a/includes/rest-routes.php
+++ b/includes/rest-routes.php
@@ -36,11 +36,12 @@ function add_endpoints() {
 /**
  * Encode String.
  *
- * @param [string] $string String to be encoded.
+ * @param [string] $unencoded_string String to be encoded.
  * @return [string]
  */
-function encode( $string ) {
-	$response = strtr( base64_encode( $string ), '+/', '-_' );
+function encode( $unencoded_string ) {
+	// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- required for JWT.
+	$response = strtr( base64_encode( $unencoded_string ), '+/', '-_' );
 	return rtrim( $response, '=' );
 }
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -31,7 +31,7 @@ function setup() {
  * @return mixed
  */
 function get_setting( $setting ) {
-	$settings = get_option( 'maps_block_apple', [] );
+	$settings = get_option( 'maps_block_apple', array() );
 	return isset( $settings[ $setting ] ) ? $settings[ $setting ] : '';
 }
 
@@ -61,7 +61,7 @@ function register_settings() {
 					),
 				),
 			),
-			'default'           => [],
+			'default'           => array(),
 			'sanitize_callback' => __NAMESPACE__ . '\sanitize_settings',
 		)
 	);
@@ -294,7 +294,7 @@ function render_credential_status() {
  * @since  1.0
  */
 function sanitize_settings( $settings ) {
-	$new_settings = [];
+	$new_settings = array();
 	if ( isset( $settings['private_key'] ) ) {
 		$new_settings['private_key'] = trim( $settings['private_key'] );
 	}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -13,8 +13,8 @@ namespace tenup\Maps_Block_Apple\Settings;
  * @since 1.0.0
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
+	$n = function ( $function_name ) {
+		return __NAMESPACE__ . "\\$function_name";
 	};
 	add_action( 'admin_menu', $n( 'admin_menu' ), 20 );
 	add_action( 'admin_init', $n( 'setup_fields_sections' ) );

--- a/maps-block-apple.php
+++ b/maps-block-apple.php
@@ -20,7 +20,7 @@ namespace tenup\Maps_Block_Apple;
 // Useful global constants.
 define( 'MAPS_BLOCK_APPLE_VERSION', '1.1.5' );
 define( 'MAPS_BLOCK_APPLE_URL', plugin_dir_url( __FILE__ ) );
-define( 'MAPS_BLOCK_APPLE_PATH', dirname( __FILE__ ) . '/' );
+define( 'MAPS_BLOCK_APPLE_PATH', __DIR__ . '/' );
 define( 'MAPS_BLOCK_APPLE_INC', MAPS_BLOCK_APPLE_PATH . 'includes/' );
 define( 'MAPS_BLOCK_APPLE_BASENAME', plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
### Description of the Change

Updates the 10up/phpcs-composer package to allow GHA actions to run.

Closes #268

### How to test the Change

Ensure the following succeed:

* E2E test build zip step (following steps - the E2E tests themselves - may fail pending #267)
* PHP Linting action


### Changelog Entry
> Developer - Update 10up/phpcs-composer to resolve security vulnerability advisories.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
